### PR TITLE
Add Jest test setup for Button component

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
@@ -31,6 +32,11 @@
     "eslint-config-next": "14.2.29",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.0",
+    "@types/jest": "^29.5.3",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.2"
   }
 }

--- a/src/components/ui/__tests__/Button.test.tsx
+++ b/src/components/ui/__tests__/Button.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { Button } from '../Button';
+
+describe('Button', () => {
+  const variantClasses: Record<string, string> = {
+    primary: 'bg-primary-600',
+    secondary: 'bg-gray-600',
+    outline: 'border-gray-300',
+    ghost: 'bg-transparent',
+  };
+
+  it.each(Object.entries(variantClasses))('renders %s variant', (variant, cls) => {
+    render(<Button variant={variant as any}>Test</Button>);
+    const button = screen.getByRole('button', { name: 'Test' });
+    expect(button.className).toContain(cls);
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest with TypeScript support and RTL
- add npm test script
- create test covering `Button` variants

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b42fde7f4833293c75c9874d1291e