### PR TITLE
fix: Update sitemap to include only existing pages

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -16,30 +16,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'monthly',
       priority: 0.8,
     },
-    // 将来的に追加予定のページ
-    {
-      url: `${baseUrl}/menu`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/concept`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/feature`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/staff`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.6,
-    },
   ];
 }


### PR DESCRIPTION
- Remove non-existent pages (/menu, /concept, /feature, /staff)
- Keep only actual pages (/, /contact)
- Fix Google Search Console sitemap fetch errors