### PR TITLE
fix: Fix sitemap lastModified to use fixed date instead of new Date()

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,16 +3,19 @@ import { MetadataRoute } from 'next';
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = 'https://hair-salon-wingr.vercel.app';
 
+  // 固定日時を使用（実際の更新に基づく）
+  const siteLastModified = new Date('2025-01-09T10:00:00+09:00');
+
   return [
     {
       url: baseUrl,
-      lastModified: new Date(),
+      lastModified: siteLastModified,
       changeFrequency: 'weekly',
       priority: 1,
     },
     {
       url: `${baseUrl}/contact`,
-      lastModified: new Date(),
+      lastModified: siteLastModified,
       changeFrequency: 'monthly',
       priority: 0.8,
     },


### PR DESCRIPTION
- Use fixed timestamp to prevent inconsistency with HTTP cache
- Resolve Google Search Console 'Could not fetch' error
- Ensure consistent sitemap generation for better SEO